### PR TITLE
adding .sdv-blueprint.json file

### DIFF
--- a/.sdv-blueprint.json
+++ b/.sdv-blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "Software Orchestration",
+  "version": "0.1.0",
+  "description": "The Software Orchestration Blueprint showcases how an example in-vehicle software architecture with connectivity to the cloud can help integrators and developers manage complex services and applications.",
+  "participatingProjects": [
+    {"id": "automotive.agemo"},
+    {"id": "automotive.ankaios"},
+    {"id": "automotive.bluechi"},
+    {"id": "automotive.chariott"},
+    {"id": "automotive.freyja"},
+    {"id": "automotive.ibeji"},
+    { "id": "automotive.kuksa" },
+    { "id": "iot.mosquitto" }
+  ]
+}

--- a/.sdv-blueprint.json.license
+++ b/.sdv-blueprint.json.license
@@ -1,0 +1,12 @@
+/********************************************************************************
+* Copyright (c) 2024 Leonardo Rossetti <lrossett@redhat.com>
+*
+* This program and the accompanying materials are made available under the 2
+* terms of the Apache License 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.txt.
+*
+* SPDX-License-Identifier: Apache-2.0
+*
+* Contributors: 1
+*   Leonardo Rossetti - file creation
+********************************************************************************/


### PR DESCRIPTION
## Changes

* Adds a `.sdv-blueprint.json` file containing project metadata (name and description) together with all Eclipse projects being used in this blueprint
  * A similar file is used in the fleet management blueprint: https://github.com/eclipse-sdv-blueprints/fleet-management/blob/main/.sdv-blueprint.json