### PR TITLE
Add DevSkim workflow and address initial warnings

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: DevSkim
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '17 19 * * 4'
+
+jobs:
+  lint:
+    name: DevSkim
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@v1
+        with:
+          ignore-globs: "*.json"
+
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: devskim-results.sarif
+          

--- a/scenarios/smart_trailer/applications/smart_trailer_application/src/main.rs
+++ b/scenarios/smart_trailer/applications/smart_trailer_application/src/main.rs
@@ -32,8 +32,9 @@ use uuid::Uuid;
 const FREQUENCY_MS_FLAG: &str = "freq_ms=";
 const MQTT_CLIENT_ID: &str = "smart-trailer-consumer";
 
-// TODO: These could be added in configuration
-const CHARIOTT_SERVICE_DISCOVERY_URI: &str = "http://0.0.0.0:50000";
+// Note: These could be provided in configuration files.
+// We ignore the DevSkim warning because this is a sample application. In production, https should be used.
+const CHARIOTT_SERVICE_DISCOVERY_URI: &str = "http://0.0.0.0:50000"; // Devskim: ignore DS137138
 
 const DEFAULT_FREQUENCY_MS: u64 = 10000; // 10 seconds
 

--- a/scenarios/smart_trailer/digital_twin_providers/trailer_connected_provider/src/main.rs
+++ b/scenarios/smart_trailer/digital_twin_providers/trailer_connected_provider/src/main.rs
@@ -26,8 +26,9 @@ use trailer_connected_provider_impl::TrailerConnectedProviderImpl;
 
 mod trailer_connected_provider_impl;
 
-// TODO: These could be added in configuration
-const CHARIOTT_SERVICE_DISCOVERY_URI: &str = "http://0.0.0.0:50000";
+// Note: These could be provided in configuration files.
+// We ignore the DevSkim warning because this is a sample application. In production, https should be used.
+const CHARIOTT_SERVICE_DISCOVERY_URI: &str = "http://0.0.0.0:50000"; // Devskim: ignore DS137138
 const PROVIDER_AUTHORITY: &str = "0.0.0.0:4020";
 
 /// Register the "is trailer connected" property's endpoint.
@@ -73,7 +74,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("The Provider has started.");
 
-    let provider_uri = format!("http://{PROVIDER_AUTHORITY}");
+    // We ignore the DevSkim warning because this is a sample application. In production, https should be used.
+    let provider_uri = format!("http://{PROVIDER_AUTHORITY}"); // DevSkim: ignore DS137138 
     debug!("The Provider URI is {}", &provider_uri);
 
     // Setup the HTTP server.

--- a/scenarios/smart_trailer/digital_twin_providers/trailer_properties_provider/src/main.rs
+++ b/scenarios/smart_trailer/digital_twin_providers/trailer_properties_provider/src/main.rs
@@ -29,8 +29,9 @@ use tonic::Status;
 
 use crate::trailer_properties_provider_impl::TrailerPropertiesProviderImpl;
 
-// TODO: These could be added in configuration
-const CHARIOTT_SERVICE_DISCOVERY_URI: &str = "http://0.0.0.0:50000";
+// Note: These could be provided in configuration files.
+// We ignore the DevSkim warning because this is a sample application. In production, https should be used.
+const CHARIOTT_SERVICE_DISCOVERY_URI: &str = "http://0.0.0.0:50000"; // DevSkim: ignore DS137138 
 const PROVIDER_AUTHORITY: &str = "0.0.0.0:4030";
 
 const DEFAULT_MIN_INTERVAL_MS: u64 = 10000; // 10 seconds
@@ -125,7 +126,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("The Provider has started.");
 
-    let provider_uri = format!("http://{PROVIDER_AUTHORITY}"); // Devskim: ignore DS137138
+    // We ignore the DevSkim warning because this is a sample application. In production, https should be used.
+    let provider_uri = format!("http://{PROVIDER_AUTHORITY}"); // DevSkim: ignore DS137138 
 
     // Get the In-vehicle Digital Twin Uri from the service discovery system
     // This could be enhanced to add retries for robustness


### PR DESCRIPTION
Closes #24. 

DevSkim is an open source set of IDE plugins, language analyzers, and rules that provide security "linting" capabilities. Link to DevSkim project: https://github.com/microsoft/DevSkim  

- Adds DevSkim workflow to run on pull request, push, and scheduled to run once a week.
- Addresses initial warnings